### PR TITLE
NGSTACK-998 upgrade bundle to ibexa version 5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,15 +15,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1']
-        symfony: ['~5.4.0']
+        php: ['8.3']
+        symfony: ['~7.3.0']
         phpunit: ['phpunit.xml']
         deps: ['normal']
-        include:
-          - php: '7.4'
-            symfony: '~5.4.0'
-            phpunit: 'phpunit.xml'
-            deps: 'low'
 
     steps:
       - uses: actions/checkout@v2

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -32,7 +32,7 @@ return (new PhpCsFixer\Config())
             'import_functions' => true,
         ],
         'list_syntax' => ['syntax' => 'short'],
-        'mb_str_functions' => true,
+        // 'mb_str_functions' => true,
         'native_constant_invocation' => true,
         'nullable_type_declaration_for_default_null_value' => true,
         'static_lambda' => true,

--- a/Core/FieldType/ContentTypeList/FormMapper.php
+++ b/Core/FieldType/ContentTypeList/FormMapper.php
@@ -20,9 +20,9 @@ final class FormMapper implements FieldValueFormMapperInterface
                         'value',
                         ContentTypeListFieldType::class,
                         [
-                            'required' => $data->fieldDefinition->isRequired,
-                            'label' => $data->fieldDefinition->getName(),
-                            'field_definition' => $data->fieldDefinition,
+                            'required' => $data->getFieldDefinition()->isRequired,
+                            'label' => $data->getFieldDefinition()->getName(),
+                            'field_definition' => $data->getFieldDefinition(),
                             'multiple' => true,
                         ]
                     )

--- a/Core/FieldType/ContentTypeList/Type.php
+++ b/Core/FieldType/ContentTypeList/Type.php
@@ -105,7 +105,7 @@ final class Type extends FieldType
         }
     }
 
-    protected function getSortInfo(BaseValue $value)
+    protected function getSortInfo(BaseValue $value): bool
     {
         return false;
     }

--- a/Core/FieldType/ContentTypeList/Value.php
+++ b/Core/FieldType/ContentTypeList/Value.php
@@ -13,17 +13,11 @@ final class Value extends BaseValue
     /**
      * The list of content type identifiers.
      *
-     * @var string[]
-     */
-    public array $identifiers = [];
-
-    /**
      * @param string[] $identifiers
      */
-    public function __construct(array $identifiers = [])
-    {
-        $this->identifiers = $identifiers;
-    }
+    public function __construct(
+        public array $identifiers = [],
+    ) {}
 
     public function __toString(): string
     {

--- a/Core/Persistence/Legacy/Content/FieldValue/Converter/ContentTypeListConverter.php
+++ b/Core/Persistence/Legacy/Content/FieldValue/Converter/ContentTypeListConverter.php
@@ -12,7 +12,7 @@ use Ibexa\Core\Persistence\Legacy\Content\StorageFieldValue;
 
 use function explode;
 use function implode;
-use function trim;
+use function mb_trim;
 
 final class ContentTypeListConverter implements Converter
 {
@@ -23,7 +23,7 @@ final class ContentTypeListConverter implements Converter
 
     public function toFieldValue(StorageFieldValue $value, FieldValue $fieldValue): void
     {
-        $data = trim($value->dataText ?? '');
+        $data = mb_trim($value->dataText ?? '');
         $fieldValue->data = empty($data) ? [] : explode(',', $data);
     }
 
@@ -31,7 +31,7 @@ final class ContentTypeListConverter implements Converter
 
     public function toFieldDefinition(StorageFieldDefinition $storageDef, FieldDefinition $fieldDef): void {}
 
-    public function getIndexColumn()
+    public function getIndexColumn(): bool
     {
         return false;
     }

--- a/Core/Persistence/Legacy/Content/FieldValue/Converter/ContentTypeListConverter.php
+++ b/Core/Persistence/Legacy/Content/FieldValue/Converter/ContentTypeListConverter.php
@@ -12,7 +12,7 @@ use Ibexa\Core\Persistence\Legacy\Content\StorageFieldValue;
 
 use function explode;
 use function implode;
-use function mb_trim;
+use function trim;
 
 final class ContentTypeListConverter implements Converter
 {
@@ -23,7 +23,7 @@ final class ContentTypeListConverter implements Converter
 
     public function toFieldValue(StorageFieldValue $value, FieldValue $fieldValue): void
     {
-        $data = mb_trim($value->dataText ?? '');
+        $data = trim($value->dataText ?? '');
         $fieldValue->data = empty($data) ? [] : explode(',', $data);
     }
 

--- a/Tests/Core/FieldType/ContentTypeList/TypeTest.php
+++ b/Tests/Core/FieldType/ContentTypeList/TypeTest.php
@@ -95,7 +95,7 @@ final class TypeTest extends TestCase
     public function testAcceptValueWithValueIdentifiersAsArrayOfNumbers(): void
     {
         $this->expectException(InvalidArgumentType::class);
-        $this->expectExceptionMessage("Argument '123' is invalid: value must be of type 'Netgen\\Bundle\\ContentTypeListBundle\\Core\\FieldType\\ContentTypeList\\Value', not 'integer'");
+        $this->expectExceptionMessage("Argument '123' is invalid: value must be of type 'Netgen\\Bundle\\ContentTypeListBundle\\Core\\FieldType\\ContentTypeList\\Value', not 'int'");
 
         $this->value->identifiers = [123, 456];
 

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,12 @@
         }
     ],
     "require": {
-        "ibexa/core": "^4.0"
+        "ibexa/core": "^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^12.0",
+        "symfony/form": "^7.3",
+        "ibexa/content-forms": "^5.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
     ],
     "require": {
         "ibexa/core": "^5.0",
-        "symfony/form": "^7.3"
+        "symfony/form": "^7.3",
+        "ibexa/content-forms": "^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^12.0",
-        "ibexa/content-forms": "^5.0"
+        "phpunit/phpunit": "^12.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
         }
     ],
     "require": {
-        "ibexa/core": "^5.0"
+        "ibexa/core": "^5.0",
+        "symfony/form": "^7.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^12.0",
-        "symfony/form": "^7.3",
         "ibexa/content-forms": "^5.0"
     },
     "minimum-stability": "dev",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,10 +1,11 @@
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.4/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
          colors="true"
+         backupGlobals="false"
+         failOnRisky="true"
+         failOnWarning="true"
          beStrictAboutTestsThatDoNotTestAnything="false"
 >
     <testsuites>
@@ -12,16 +13,16 @@
             <directory>Tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <source>
+        <include>
             <directory>.</directory>
-            <exclude>
-                <directory>DependencyInjection</directory>
-                <directory>Resources</directory>
-                <directory>Tests</directory>
-                <directory>vendor</directory>
-                <file>NetgenContentTypeListBundle.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory>DependencyInjection</directory>
+            <directory>Resources</directory>
+            <directory>Tests</directory>
+            <directory>vendor</directory>
+            <file>NetgenContentTypeListBundle.php</file>
+        </exclude>
+    </source>
 </phpunit>


### PR DESCRIPTION
Upgraded bundle to use Ibexa version 5. 
Made small changes to code (because of PHP8). 
Modified `phpunit.xml` file to newer version and bumped the PHP and Symfony versions in `tests.yml` workflow. 